### PR TITLE
Add 'pkg/health' package.

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -55,7 +55,6 @@ func NewHTTPHandler(serviceName string, checkers []Checker) http.Handler {
 func handlePing(msg []byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
 		w.Write(msg)
 	}
 }
@@ -90,7 +89,6 @@ func handleReady(checkers []Checker) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(resp)
-		w.WriteHeader(http.StatusOK)
 	}
 }
 
@@ -118,5 +116,4 @@ func handleLive(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(resp)
-	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,122 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+)
+
+type (
+	response struct {
+		Status string  `json:"status"`           // UP or DOWN
+		Checks []Check `json:"checks,omitempty"` // List of checks. Most likely external services
+		Data   any     `json:"data,omitempty"`
+	}
+
+	Check struct {
+		Name     string `json:"name"`              // Name of the external service being checked
+		Status   string `json:"status"`            // UP or DOWN
+		Critical bool   `json:"critical"`          // If true, the service is considered down
+		Message  string `json:"message,omitempty"` // Optional message. Could be used for errors
+	}
+
+	// Checker function should perform a check of some sort of external service
+	Checker func() Check
+
+	system struct {
+		Memory memory `json:"memory"`
+		CPU    cpu    `json:"-"` // TODO: implement
+	}
+
+	memory struct {
+		Used int64 `json:"used"` // bytes used on the heap
+		Free int64 `json:"free"` // bytes free on the heap
+	}
+
+	cpu struct {
+		Used int64 `json:"used"` // cpu used in nanoseconds
+		Free int64 `json:"free"` // cpu free in nanoseconds
+	}
+)
+
+func NewHTTPHandler(serviceName string, checkers []Checker) http.Handler {
+	router := http.NewServeMux()
+	router.HandleFunc(
+		"/health/ping",
+		handlePing([]byte(fmt.Sprintf("pong from %s", serviceName))),
+	)
+	router.HandleFunc("/health/ready", handleReady(checkers))
+	router.HandleFunc("/health/live", handleLive)
+
+	return router
+}
+
+func handlePing(msg []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write(msg)
+	}
+}
+
+func handleReady(checkers []Checker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		status := "UP"
+		checks := make([]Check, len(checkers))
+		for i, checker := range checkers {
+			check := checker()
+			checks[i] = check
+			if check.Status != "UP" {
+				if check.Critical {
+					status = "DOWN"
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}
+
+		resp, err := json.Marshal(response{
+			Status: status,
+			Checks: checks,
+		})
+		if err != nil {
+			http.Error(
+				w,
+				fmt.Sprintf("could not marshal response err: %s", err.Error()),
+				http.StatusInternalServerError,
+			)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(resp)
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func handleLive(w http.ResponseWriter, r *http.Request) {
+	memStats := runtime.MemStats{}
+	runtime.ReadMemStats(&memStats)
+
+	resp, err := json.Marshal(response{
+		Status: "UP",
+		Data: system{
+			Memory: memory{
+				Used: int64(memStats.Alloc),
+				Free: int64(memStats.Sys - memStats.Alloc),
+			},
+		},
+	})
+	if err != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("could not marshal response err: %s", err.Error()),
+			http.StatusInternalServerError,
+		)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(resp)
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,178 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestPing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health/ping", nil)
+	w := httptest.NewRecorder()
+
+	var (
+		serviceName  = "test-service"
+		expectedResp = fmt.Sprintf("pong from %s", serviceName)
+	)
+
+	handlePing([]byte(expectedResp))(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf(
+			"expected content type %s, got %s", "text/plain",
+			resp.Header.Get("Content-Type"),
+		)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("expected no error, got %s", err.Error())
+	}
+
+	if string(data) != expectedResp {
+		t.Errorf("expected body %q, got %q", expectedResp, string(data))
+	}
+}
+
+func TestReady(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
+	w := httptest.NewRecorder()
+
+	var (
+		expectedRespCheck = Check{
+			Name:     "databaseConnection",
+			Status:   "UP",
+			Critical: true,
+			Message:  "database connection is up",
+		}
+
+		checkers = []Checker{
+			func() Check {
+				return expectedRespCheck
+			},
+		}
+
+		expectedResp = response{
+			Status: "UP",
+			Checks: []Check{expectedRespCheck},
+		}
+	)
+
+	handleReady(checkers)(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf(
+			"expected content type %s, got %s", "application/json",
+			resp.Header.Get("Content-Type"),
+		)
+	}
+
+	actualResp := response{}
+	if err := json.NewDecoder(resp.Body).Decode(&actualResp); err != nil {
+		t.Errorf("decoding response, expected no error, got %s", err.Error())
+	}
+
+	if actualResp.Status != expectedResp.Status {
+		t.Errorf(
+			"incorrect status in response, expected status %s, got %s",
+			expectedResp.Status,
+			actualResp.Status,
+		)
+	}
+
+	if len(actualResp.Checks) != len(expectedResp.Checks) {
+		t.Fatalf(
+			"incorrect number of checks in response, expected %d checks, got %d, actual checks: %v",
+			len(expectedResp.Checks),
+			len(actualResp.Checks),
+			actualResp.Checks,
+		)
+	}
+
+	for i := 0; i < len(actualResp.Checks)-1; i++ {
+		if !reflect.DeepEqual(actualResp.Checks[i], expectedResp.Checks[i]) {
+			t.Errorf(
+				"expected check %v, got %v",
+				expectedResp.Checks[i],
+				actualResp.Checks[i],
+			)
+		}
+	}
+}
+
+func TestLive(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health/live", nil)
+	w := httptest.NewRecorder()
+
+	handleLive(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf(
+			"expected content type %s, got %s", "application/json",
+			resp.Header.Get("Content-Type"),
+		)
+	}
+
+	actualResp := response{}
+	if err := json.NewDecoder(resp.Body).Decode(&actualResp); err != nil {
+		t.Errorf("decoding response, expected no error, got %s", err.Error())
+	}
+
+	if actualResp.Status != "UP" {
+		t.Errorf("expected status %s, got %s", "UP", actualResp.Status)
+	}
+
+	if len(actualResp.Checks) != 0 {
+		t.Errorf("expected no checks, got %d", len(actualResp.Checks))
+	}
+
+	if actualResp.Data == nil {
+		t.Fatal("expected data to be present, got nil")
+	}
+
+	data, ok := actualResp.Data.(map[string]any)
+
+	if !ok {
+		t.Errorf("expected data to be of type map[string]any, got %T", actualResp.Data)
+	}
+
+	m, ok := data["memory"]
+	if !ok {
+		t.Errorf("expected data to have field memory, got %v", data)
+	}
+
+	mem, ok := m.(map[string]any)
+	if !ok {
+		t.Errorf("expected data.memory to be of type memory, got %T", m)
+	}
+
+	if _, ok := mem["used"]; !ok {
+		t.Errorf("expected data.memory to have field used, got %v", mem)
+	}
+
+	if _, ok := mem["free"]; !ok {
+		t.Errorf("expected data.memory to have field free, got %v", mem)
+	}
+}


### PR DESCRIPTION
This package provides a very minimalist handler for health checks. It written as a default http.Handler.
Also added some tests for this package too.

# Usage example

```go
package main

import (
	"net/http"

	"github.com/sultanaliev-s/kiteps/pkg/health"
)

func main() {
	http.Handle("/", health.NewHTTPHandler("test-service", []health.Checker{
		func() health.Check {
                        // Do some checks here
			return health.Check{
				Name:     "databaseConnection",
				Status:   "UP",
				Critical: true,
				Message:  "database connection is up",
			}
		},
	}))
	http.ListenAndServe(":8080", nil)
}
```

This handler will create 3 endpoints

* `/health/ping` - Will simply return status code 200, and text like 'pong from (service name)'
* `/health/ready` - Will perform checks with functions you provide, and return to you the status of those checks
* `/health/live` - Will return to you the memory usage. In future this endpoint might do a little more than that :)